### PR TITLE
feat: Derive Clone for HdfsObjectStore

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,7 +41,7 @@ use tokio::{
 #[cfg(feature = "integration-test")]
 pub use hdfs_native::minidfs;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct HdfsObjectStore {
     client: Arc<Client>,
 }


### PR DESCRIPTION
@Kimahriman 
I noticed that we currently derive Clone for `HdfsObjectStore`.
Unless we have a good reason not to, it would be great to add it :)