### PR TITLE
fix: list(None) is logically equivalent to list("/")

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -338,7 +338,7 @@ impl ObjectStore for HdfsObjectStore {
         let status_stream = self
             .client
             .list_status_iter(
-                &prefix.map(make_absolute_dir).unwrap_or("".to_string()),
+                &prefix.map(make_absolute_dir).unwrap_or("/".to_string()),
                 true,
             )
             .into_stream()

--- a/tests/test_object_store.rs
+++ b/tests/test_object_store.rs
@@ -79,6 +79,11 @@ mod test {
         assert_eq!(list.len(), 1);
         assert_eq!(list[0].as_ref().unwrap().location, Path::from("/testfile"));
 
+        // A list of None should be logically equivalent to /
+        let list: Vec<object_store::Result<ObjectMeta>> = store.list(None).collect().await;
+        assert_eq!(list.len(), 1);
+        assert_eq!(list[0].as_ref().unwrap().location, Path::from("/testfile"));
+
         // Listing of a prefix that doesn't exist should return an empty result, not an error
         assert_eq!(
             store.list(Some(&Path::from("/doesnt/exist"))).count().await,


### PR DESCRIPTION
Sending minidfs a list operation of an empty string does not appear to be valid, added a regression test here too.

        ---- test::test_object_store stdout ----

        thread 'test::test_object_store' panicked at tests/test_object_store.rs:86:37:
        called `Result::unwrap()` on an `Err` value: Generic { store: "HdfsObjectStore", source: RPCError("java.lang.AssertionError", "Absolute path required, but got ''\n\tat org.apache.hadoop.hdfs.server.namenode.INode.checkAbsolutePath(INode.java:849)\n\tat org.apache.hadoop.hdfs.server.namenode.INode.getPathComponents(INode.java:824)\n\tat org.apache.hadoop.hdfs.server.namenode.FSDirectory.resolvePath(FSDirectory.java:726)\n\tat org.apache.hadoop.hdfs.server.namenode.FSDirStatAndListingOp.getListingInt(FSDirStatAndListingOp.java:57)\n\tat org.apache.hadoop.hdfs.server.namenode.FSNamesystem.getListing(FSNamesystem.java:4200)\n\tat org.apache.hadoop.hdfs.server.namenode.NameNodeRpcServer.getListing(NameNodeRpcServer.java:1195)\n\tat org.apache.hadoop.hdfs.protocolPB.ClientNamenodeProtocolServerSideTranslatorPB.getListing(ClientNamenodeProtocolServerSideTranslatorPB.java:762)\n\tat org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos$ClientNamenodeProtocol$2.callBlockingMethod(ClientNamenodeProtocolProtos.java)\n\tat org.apache.hadoop.ipc.ProtobufRpcEngine2$Server$ProtoBufRpcInvoker.call(ProtobufRpcEngine2.java:621)\n\tat org.apache.hadoop.ipc.ProtobufRpcEngine2$Server$ProtoBufRpcInvoker.call(ProtobufRpcEngine2.java:589)\n\tat org.apache.hadoop.ipc.ProtobufRpcEngine2$Server$ProtoBufRpcInvoker.call(ProtobufRpcEngine2.java:573)\n\tat org.apache.hadoop.ipc.RPC$Server.call(RPC.java:1227)\n\tat org.apache.hadoop.ipc.Server$RpcCall.run(Server.java:1246)\n\tat org.apache.hadoop.ipc.Server$RpcCall.run(Server.java:1169)\n\tat java.base/java.security.AccessController.doPrivileged(Native Method)\n\tat java.base/javax.security.auth.Subject.doAs(Subject.java:423)\n\tat org.apache.hadoop.security.UserGroupInformation.doAs(UserGroupInformation.java:1953)\n\tat org.apache.hadoop.ipc.Server$Handler.run(Server.java:3198)\n") }
        note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
        Dropping and killing minidfs