### PR TITLE
Add builder API and remove unnecessary Arcs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -535,9 +535,9 @@ checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "hdfs-native"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23709a4e6b07f231c28608b9c84a873157221cae9674478ca7569ec5ac505517"
+checksum = "0f2446941d466dabd56a44f77ee435e4501a68dfc5022ed18b7626606ce95570"
 dependencies = [
  "aes",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ async-trait = "0.1"
 bytes = "1"
 chrono = "0.4"
 futures = "0.3"
-hdfs-native = "0.12"
+hdfs-native = "0.12.1"
 object_store = "0.12.2"
 thiserror = "2"
 tokio = { version = "1", features = ["rt", "net", "io-util", "macros", "sync", "time"] }

--- a/README.md
+++ b/README.md
@@ -12,12 +12,12 @@ Each release supports a certain minor release of both the `object_store` crate a
 |0.12.x|>=0.10, <0.12|0.10|
 |0.13.x|>=0.10, <0.12|0.11|
 |0.14.x|0.12|0.11|
-|0.15.x|0.12|0.12|
+|0.15.x|>=0.12.2, <0.13|0.12|
 
 # Usage
 ```rust
-use hdfs_native_object_store::HdfsObjectStore;
-let store = HdfsObjectStore::with_url("hdfs://localhost:9000")?;
+use hdfs_native_object_store::HdfsObjectStoreBuilder;
+let store = HdfsObjectStoreBuilder::new().with_url("hdfs://localhost:9000").build()?;
 ```
 
 # Documentation


### PR DESCRIPTION
Resolves #24 

- Add a builder API to create a new store
- Support the new dedicated IO runtime support in the Client
- Remove extra ARc wrapping the client because `Client` is cheap to clone